### PR TITLE
Add package version to installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The package accepts flags to specify the directory to load files from, the file 
 If you have Go installed, you can install the package by running the following command:
 
 ```bash
-$ go install github.com/alesr/codetoprompt
+$ go install github.com/alesr/codetoprompt@latest
 ```
 
 You can also use Homebrew to install the package:


### PR DESCRIPTION
Installation command in the Readme is missing the `@latest` part, and attempt to run ends with
```
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/alesr/codetoprompt@latest' to install the latest version
```